### PR TITLE
collider: adjust box collider size

### DIFF
--- a/MREGodotRuntimeLib/Assets/AssetLoader.cs
+++ b/MREGodotRuntimeLib/Assets/AssetLoader.cs
@@ -723,7 +723,7 @@ namespace MixedRealityExtension.Assets
 				case PrimitiveShape.Box:
 					return new BoxColliderGeometry()
 					{
-						Size = new MWVector3(dims.X / 2, dims.Y / 2, dims.Z / 2) ?? new MWVector3(0.5f, 0.5f, 0.5f)
+						Size = dims ?? new MWVector3(1, 1, 1)
 					};
 
 				case PrimitiveShape.Capsule:

--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -1013,11 +1013,7 @@ namespace MixedRealityExtension.Core
 			switch (colliderType)
 			{
 				case ColliderType.Box:
-					var boxCollider = new CollisionShape() {
-						Shape = new BoxShape() {
-							Extents = new Vector3(0.5f, 0.5f, 0.5f)
-						}
-					};
+					var boxCollider = new CollisionShape() { Shape = new BoxShape() };
 					colliderGeometry.Patch(App, boxCollider);
 					godotCollisionShape = boxCollider;
 					break;

--- a/MREGodotRuntimeLib/Core/ColliderGeometry.cs
+++ b/MREGodotRuntimeLib/Core/ColliderGeometry.cs
@@ -98,9 +98,9 @@ namespace MixedRealityExtension.Core
 				if (Size != null)
 				{
 					Vector3 newSize;
-					newSize.x = Size.X;
-					newSize.y = Size.Y;
-					newSize.z = Size.Z;
+					newSize.x = Size.X / 2;
+					newSize.y = Size.Y / 2;
+					newSize.z = Size.Z / 2;
 					boxShape.Extents = newSize * 0.999998f;
 				}
 			}


### PR DESCRIPTION
In Godot, `BoxShape.Extents` means 'half extents'. but mre is not.
So, we need to apply half of value to the Extents.

See also, Godot Document of `BoxShape.Extents`:
```
The box's half extents. The width, height and depth of this shape is
twice the half extents.
```