### PR TITLE
refactoring internal event system

### DIFF
--- a/MREGodotRuntime/Scripts/Tools/ButtonTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/ButtonTool.cs
@@ -33,8 +33,9 @@ namespace Assets.Scripts.Tools
 					}
 				}
 				pressed = true;
-				var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityPointerHandler>(Target);
-				handler?.OnPointerDown(new MixedRealityPointerEventData(this, CurrentTargetPoint));
+
+				Target.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerDown),
+															new MixedRealityPointerEventData(this, CurrentTargetPoint));
 			}
 			else if (Input.IsActionJustReleased("Fire1"))
 			{
@@ -49,8 +50,9 @@ namespace Assets.Scripts.Tools
 					}
 				}
 				pressed = false;
-				var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityPointerHandler>(Target);
-				handler?.OnPointerUp(new MixedRealityPointerEventData(this, CurrentTargetPoint));
+
+				Target.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerUp),
+															new MixedRealityPointerEventData(this, CurrentTargetPoint));
 			}
 			else
 			{
@@ -106,8 +108,8 @@ namespace Assets.Scripts.Tools
 		{
 			if (pressed)
 			{
-				var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityPointerHandler>(Target);
-				handler?.OnPointerDragged(new MixedRealityPointerEventData(this, CurrentTargetPoint));
+				Target.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerDragged),
+														new MixedRealityPointerEventData(this, CurrentTargetPoint));
 			}
 		}
 	}

--- a/MREGodotRuntime/Scripts/Tools/PokeTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/PokeTool.cs
@@ -51,7 +51,7 @@ namespace Assets.Scripts.Tools
 				var collider = (Spatial)intersectResult["collider"];
 				Spatial actor = null;
 
-				for (actor = collider; actor != null; actor = actor.GetParent<Spatial>())
+				for (actor = collider; actor != null; actor = actor.GetParent() as Spatial)
 					if (actor is Actor) break;
 
 				if (actor == null || !((Actor)actor).Touchable)
@@ -103,7 +103,7 @@ namespace Assets.Scripts.Tools
 				var collider = (Spatial)IntersectRayResult["collider"];
 				Spatial actor;
 
-				for (actor = collider; actor != null; actor = actor.GetParent<Spatial>())
+				for (actor = collider; actor != null; actor = actor.GetParent() as Spatial)
 					if (actor is Actor) break;
 
 				if (actor == null || !((Actor)actor).Touchable)
@@ -169,8 +169,8 @@ namespace Assets.Scripts.Tools
 							buttonBehavior.Context.StartButton(mwUser, IntersectionPosition);
 							((SpatialMaterial)inputSource.CollisionPoint.MaterialOverride).AlbedoColor = new Color(1, 0, 0);
 
-							var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityTouchHandler>(CurrentTouchableObjectDown);
-							if (handler != null) handler.OnTouchStarted(new TouchInputEventData(this, IntersectionPosition));
+							CurrentTouchableObjectDown.HandleEvent<IMixedRealityTouchHandler>(nameof(IMixedRealityTouchHandler.OnTouchStarted),
+																							new TouchInputEventData(this, IntersectionPosition));
 						}
 					}
 				}
@@ -194,8 +194,8 @@ namespace Assets.Scripts.Tools
 						buttonBehavior.Context.EndButton(mwUser, IntersectionPosition);
 						buttonBehavior.Context.Click(mwUser, IntersectionPosition);
 
-						var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityTouchHandler>(CurrentTouchableObjectDown);
-						if (handler != null) handler.OnTouchCompleted(new TouchInputEventData(this, IntersectionPosition));
+						CurrentTouchableObjectDown.HandleEvent<IMixedRealityTouchHandler>(nameof(IMixedRealityTouchHandler.OnTouchCompleted),
+																						new TouchInputEventData(this, IntersectionPosition));
 					}
 				}
 
@@ -207,8 +207,8 @@ namespace Assets.Scripts.Tools
 		{
 			if (CurrentTouchableObjectDown != null)
 			{
-				var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityTouchHandler>(CurrentTouchableObjectDown);
-				if (handler != null) handler.OnTouchUpdated(new TouchInputEventData(this, IntersectionPosition));
+				CurrentTouchableObjectDown.HandleEvent<IMixedRealityTouchHandler>(nameof(IMixedRealityTouchHandler.OnTouchUpdated),
+																				new TouchInputEventData(this, IntersectionPosition));
 			}
 		}
 

--- a/MREGodotRuntime/Scripts/Tools/SphereTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/SphereTool.cs
@@ -101,7 +101,6 @@ namespace Assets.Scripts.Tools
 		{
 			if (currentGrabbableActor != null)
 			{
-				var handler = IMixedRealityEventHandler.FindEventHandler<IMixedRealityPointerHandler>(currentGrabbableActor);
 				if (inputSource.PinchChaged)
 				{
 					if (inputSource.IsPinching)
@@ -109,18 +108,21 @@ namespace Assets.Scripts.Tools
 						if (!isSelectPressed)
 						{
 							isSelectPressed = true;
-							handler?.OnPointerDown(new MixedRealityPointerEventData(this, hitPoint));
+							currentGrabbableActor.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerDown),
+																						new MixedRealityPointerEventData(this, hitPoint));
 						}
 					}
 					else
 					{
 						isSelectPressed = false;
-						handler?.OnPointerUp(new MixedRealityPointerEventData(this, hitPoint));
+						currentGrabbableActor.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerUp),
+																					new MixedRealityPointerEventData(this, hitPoint));
 					}
 				}
 				else if (isSelectPressed)
 				{
-					handler?.OnPointerDragged(new MixedRealityPointerEventData(this, hitPoint));
+					currentGrabbableActor.HandleEvent<IMixedRealityPointerHandler>(nameof(IMixedRealityPointerHandler.OnPointerDragged),
+																				new MixedRealityPointerEventData(this, hitPoint));
 				}
 
 			}

--- a/MREGodotRuntime/Scripts/Tools/TargetTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/TargetTool.cs
@@ -166,16 +166,16 @@ namespace Assets.Scripts.Tools
 			{
 				_currentTargetBehavior.Context.EndTargeting(_currentTargetBehavior.GetMWUnityUser(inputSource.UserNode), oldTargetPoint);
 
-				var handler = IMixedRealityFocusHandler.FindEventHandler<IMixedRealityFocusHandler>(oldTarget);
-				handler?.OnFocusExit(new MixedRealityFocusEventData(this, oldTarget, newTarget));
+				oldTarget.HandleEvent<IMixedRealityFocusHandler>(nameof(IMixedRealityFocusHandler.OnFocusExit),
+																new MixedRealityFocusEventData(this, oldTarget, newTarget));
 			}
 
 			if (newTarget != null && Godot.Object.IsInstanceValid(newTarget) && !IsNearObject)
 			{
 				newBehavior.Context.StartTargeting(newBehavior.GetMWUnityUser(inputSource.UserNode), newTargetPoint);
 
-				var handler = IMixedRealityFocusHandler.FindEventHandler<IMixedRealityFocusHandler>(newTarget);
-				handler?.OnFocusEnter(new MixedRealityFocusEventData(this, oldTarget, newTarget));
+				newTarget.HandleEvent<IMixedRealityFocusHandler>(nameof(IMixedRealityFocusHandler.OnFocusEnter),
+																new MixedRealityFocusEventData(this, oldTarget, newTarget));
 			}
 
 			CurrentTargetPoint = newTargetPoint;
@@ -239,7 +239,8 @@ namespace Assets.Scripts.Tools
 							{
 								inputSource.CollisionPoint.GlobalTransform = newTransform;
 							}
-							return node;
+
+							return a;
 						}
 						else
 						{

--- a/Toolkit/EventHandlerExtensions.cs
+++ b/Toolkit/EventHandlerExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Reflection;
+using Godot;
+using Microsoft.MixedReality.Toolkit.UI;
+using MixedRealityExtension.Util.GodotHelper;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    public static class EventHandlerExtensions
+    {
+        public static void HandleEvent<T>(this Node node, string signal, params Godot.Object[] args) where T : class
+        {
+            while (node != null)
+            {
+                var handler = node.GetChild<T>() as Node;
+
+                handler?.EmitSignal(signal, args);
+                node = node.GetParent() as Node;
+            }
+            foreach (var arg in args)
+            {
+                arg.Dispose();
+            }
+        }
+
+        public static void RegisterHandler<T>(this Node node)
+        {
+            foreach (var signal in typeof(T).GetMembers().Where(m => m.GetCustomAttribute<SignalAttribute>() != null))
+            {
+                node.AddUserSignal(signal.Name);
+                node.Connect(signal.Name, node, signal.Name);
+            }
+        }
+    }
+}

--- a/Toolkit/IMixedRealityEventHandler.cs
+++ b/Toolkit/IMixedRealityEventHandler.cs
@@ -1,21 +1,6 @@
-﻿using Godot;
-using MixedRealityExtension.Util.GodotHelper;
-
-namespace Microsoft.MixedReality.Toolkit.Input
+﻿namespace Microsoft.MixedReality.Toolkit.Input
 {
     public interface IMixedRealityEventHandler
     {
-        public static T FindEventHandler<T>(Node node) where T : class
-        {
-            var handler = node.GetChild<T>();
-            while (handler == null)
-            {
-                node = node.GetParent<Node>();
-                if (node == null) return null;
-                handler = node.GetChild<T>();
-            }
-
-            return handler;
-        }
     }
 }

--- a/Toolkit/IMixedRealityFocusHandler.cs
+++ b/Toolkit/IMixedRealityFocusHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Godot;
+
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
@@ -11,11 +13,13 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// The Focus Enter event is raised on this Spatial whenever a TargetTool's focus enters this Parent Actor.
         /// </summary>
-        void OnFocusEnter(MixedRealityFocusEventData eventData);
+        [Signal]
+        delegate void OnFocusEnter(MixedRealityFocusEventData eventData);
 
         /// <summary>
         /// The Focus Exit event is raised on this Spatial whenever a TargetTool's focus leaves this  Parent Actor.
         /// </summary>
-        void OnFocusExit(MixedRealityFocusEventData eventData);
+        [Signal]
+        delegate void OnFocusExit(MixedRealityFocusEventData eventData);
     }
 }

--- a/Toolkit/IMixedRealityPointerHandler.cs
+++ b/Toolkit/IMixedRealityPointerHandler.cs
@@ -13,21 +13,25 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// <summary>
         /// When a pointer down event is raised, this method is used to pass along the event data to the input handler.
         /// </summary>
-        void OnPointerDown(MixedRealityPointerEventData eventData);
+        [Signal]
+        delegate void OnPointerDown(MixedRealityPointerEventData eventData);
 
         /// <summary>
         /// Called every frame a pointer is down. Can be used to implement drag-like behaviors.
         /// </summary>
-        void OnPointerDragged(MixedRealityPointerEventData eventData);
+        [Signal]
+        delegate void OnPointerDragged(MixedRealityPointerEventData eventData);
 
         /// <summary>
         /// When a pointer up event is raised, this method is used to pass along the event data to the input handler.
         /// </summary>
-        void OnPointerUp(MixedRealityPointerEventData eventData);
+        [Signal]
+        delegate void OnPointerUp(MixedRealityPointerEventData eventData);
 
         /// <summary>
         /// When a pointer clicked event is raised, this method is used to pass along the event data to the input handler.
         /// </summary>
-        void OnPointerClicked(MixedRealityPointerEventData eventData);
+        [Signal]
+        delegate void OnPointerClicked(MixedRealityPointerEventData eventData);
     }
 }

--- a/Toolkit/IMixedRealityTouchHandler.cs
+++ b/Toolkit/IMixedRealityTouchHandler.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Godot;
+
 namespace Microsoft.MixedReality.Toolkit.Input
 {
     /// <summary>
@@ -15,7 +17,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// A Touch motion is defined as occurring within the bounds of an object (transitive).
         /// </remarks>
         /// <param name="eventData">Contains information about the HandTrackingInputSource.</param>
-        void OnTouchStarted(TouchInputEventData eventData);
+        [Signal]
+        delegate void OnTouchStarted(TouchInputEventData eventData);
 
         /// <summary>
         /// When a Touch motion ends, this handler receives the event.
@@ -24,7 +27,8 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// A Touch motion is defined as occurring within the bounds of an object (transitive).
         /// </remarks>
         /// <param name="eventData">Contains information about the HandTrackingInputSource.</param>
-        void OnTouchCompleted(TouchInputEventData eventData);
+        [Signal]
+        delegate void OnTouchCompleted(TouchInputEventData eventData);
 
         /// <summary>
         /// When a Touch motion is updated, this handler receives the event.
@@ -33,6 +37,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         /// A Touch motion is defined as occurring within the bounds of an object (transitive).
         /// </remarks>
         /// <param name="eventData">Contains information about the HandTrackingInputSource.</param>
-        void OnTouchUpdated(TouchInputEventData eventData);
+        [Signal]
+        delegate void OnTouchUpdated(TouchInputEventData eventData);
     }
 }

--- a/Toolkit/InputEventData.cs
+++ b/Toolkit/InputEventData.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.MixedReality.Toolkit.Input
 {
-    public abstract class InputEventData<T>
+    public abstract class InputEventData<T> : Godot.Object
     {
         /// <summary>
         /// The input data of the event.
@@ -18,7 +18,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
         public Tool Tool { get; set; }
     }
 
-    public abstract class InputEventData
+    public abstract class InputEventData : Godot.Object
     {
         public InputEventData(Tool tool)
         {

--- a/Toolkit/PinchSlider.cs
+++ b/Toolkit/PinchSlider.cs
@@ -247,6 +247,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 			{
 				throw new Exception($"Slider thumb on Spatial {Name} is not specified. Did you forget to set it?");
 			}
+
+			this.RegisterHandler<IMixedRealityPointerHandler>();
+			this.RegisterHandler<IMixedRealityTouchHandler>();
+
 			thumbActor.GetParent<Node>().RemoveChild(thumbActor);
 			AddChild(thumbActor);
 			UpdateThumbActor();

--- a/Toolkit/PressableButton.cs
+++ b/Toolkit/PressableButton.cs
@@ -285,6 +285,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         public override void _Ready()
         {
             hasStarted = true;
+            this.RegisterHandler<IMixedRealityTouchHandler>();
 /*
             if (gameObject.layer == 2)
             {
@@ -402,7 +403,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             return false;
         }
 
-        void IMixedRealityTouchHandler.OnTouchStarted(TouchInputEventData eventData)
+        void OnTouchStarted(TouchInputEventData eventData)
         {
             if (touchPoints.ContainsKey(eventData.Tool))
             {
@@ -421,7 +422,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             IsTouching = true;
         }
 
-        void IMixedRealityTouchHandler.OnTouchUpdated(TouchInputEventData eventData)
+        void OnTouchUpdated(TouchInputEventData eventData)
         {
             if (touchPoints.ContainsKey(eventData.Tool))
             {
@@ -429,7 +430,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        void IMixedRealityTouchHandler.OnTouchCompleted(TouchInputEventData eventData)
+        void OnTouchCompleted(TouchInputEventData eventData)
         {
             if (touchPoints.ContainsKey(eventData.Tool))
             {

--- a/Toolkit/PressableButtonGodot.cs
+++ b/Toolkit/PressableButtonGodot.cs
@@ -39,6 +39,9 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
 		public override void _Ready()
 		{
+			base._Ready();
+			this.RegisterHandler<IMixedRealityFocusHandler>();
+
 			BackPlate = GetNode<MeshInstance>("BackPlate");
 			BackPlateMaterial = BackPlate.MaterialOverride.Duplicate(true) as ShaderMaterial;
 			BackPlate.MaterialOverride = BackPlateMaterial;


### PR DESCRIPTION
This patch fixes event bubbling issue. even if the child object handles the
event, it should be propagated to the parent object.
new parents class called Godot.Object is introduced for InputEventData because
only the Godot.Variant type is accepted as signal arguments in Godot Signal System.