### PR TITLE
toolkit: fix invalid cast exception in clipping component

### DIFF
--- a/MREGodotRuntimeLib/Core/Components/ClippingComponent.cs
+++ b/MREGodotRuntimeLib/Core/Components/ClippingComponent.cs
@@ -62,8 +62,9 @@ namespace MixedRealityExtension.Core.Components
 			globalTransform.basis = globalTransform.basis.Scaled(Vector3Half);
 			foreach (var meshInstance in meshInstances)
 			{
-				if (meshInstance.IsVisibleInTree())
-					((ShaderMaterial)(meshInstance.MaterialOverride)).SetShaderParam("clipBoxInverseTransform", globalTransform.AffineInverse());
+				if (meshInstance.IsVisibleInTree()
+					&& meshInstance.MaterialOverride is ShaderMaterial shaderMaterial)
+					shaderMaterial.SetShaderParam("clipBoxInverseTransform", globalTransform.AffineInverse());
 			}
 		}
 


### PR DESCRIPTION
When the material is `SpatialMaterial`, we need to wait for shader compilation.
If `Process()` is called before the shader complilation, MaterialOverride will
throw invalid cast exception. to avoid exception, this patch adds type checking
condition.