### PR TITLE
fix raycast destination coordinates in PokeTool

### DIFF
--- a/MREGodotRuntime/Scripts/Tools/PokeTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/PokeTool.cs
@@ -94,8 +94,9 @@ namespace Assets.Scripts.Tools
 
 			ClosestProximityTouchable = touchable;
 
-			RayStartPoint = inputSource.PokePointer.GlobalTransform.origin + inputSource.PokePointer.GlobalTransform.basis.z.Normalized() * TouchableDistance;
-			Vector3 to = -inputSource.PokePointer.GlobalTransform.basis.z.Normalized() * 1.5f;
+			var touchableVector = inputSource.PokePointer.GlobalTransform.basis.z.Normalized() * TouchableDistance;
+			RayStartPoint = inputSource.PokePointer.GlobalTransform.origin + touchableVector;
+			Vector3 to = inputSource.PokePointer.GlobalTransform.origin - touchableVector;
 			var IntersectRayResult = spaceState.IntersectRay(RayStartPoint, to, collideWithAreas: true);
 			if (IntersectRayResult.Count > 0)
 			{


### PR DESCRIPTION
PokeTool was only working on objects with (0, 0, 0) translation.
This patch fixes this issue :)