### PR TITLE
use RemoteTransform instead of changing the parent for attachment

### DIFF
--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -795,9 +795,6 @@ namespace MixedRealityExtension.Core
 					{
 						attachmentComponent.Actor = null;
 						attachmentComponent.QueueFree();
-
-						var parent = Parent != null ? (Parent as Actor) : App.SceneRoot;
-						parent.AddChild(this);
 					}
 				}
 			}
@@ -826,8 +823,10 @@ namespace MixedRealityExtension.Core
 						var attachmentComponent = attachPoint.AddNode(new MREAttachmentComponent());
 						attachmentComponent.Actor = this;
 						attachmentComponent.UserId = Attachment.UserId;
-						this.GetParent().RemoveChild(this);
-						attachPoint.AddChild(this);
+						attachmentComponent.Transform = this.Transform;
+						attachmentComponent.UpdateScale = false;
+						attachmentComponent.RemotePath = attachmentComponent.GetPathTo(this);
+
 						hostAppUser.BeforeAvatarDestroyed += UserInfo_BeforeAvatarDestroyed;
 						return true;
 					}

--- a/MREGodotRuntimeLib/Core/Components/MREAttachmentComponent.cs
+++ b/MREGodotRuntimeLib/Core/Components/MREAttachmentComponent.cs
@@ -9,7 +9,7 @@ using Godot;
 
 namespace MixedRealityExtension.Core.Components
 {
-	internal class MREAttachmentComponent : Node
+	internal class MREAttachmentComponent : RemoteTransform
 	{
 		public Guid UserId { get; set; }
 


### PR DESCRIPTION
Changing the parent of an actor can cause sync issues between clients.
To avoid this, use RemoteTrasform instead.