### PR TITLE
fix web request failure condition

### DIFF
--- a/MREGodotRuntimeLib/Assets/AssetFetcher.cs
+++ b/MREGodotRuntimeLib/Assets/AssetFetcher.cs
@@ -131,7 +131,7 @@ namespace MixedRealityExtension.Assets
 									result.Asset = ((DownloadHandlerTexture)handler).Texture as T;
 								}
 							}
-							else
+							else if (result.ReturnCode >= 400)
 							{
 								result.FailureMessage = $"[{result.ReturnCode}] {uri}";
 							}


### PR DESCRIPTION
The 3xx return code is not a failure.
Now, we can load properly cached web resources.