### PR TITLE
override _process instead of inheriting RemoteTrasnform to update attachment

### DIFF
--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -819,10 +819,8 @@ namespace MixedRealityExtension.Core
 						var attachmentComponent = attachPoint.AddNode(new MREAttachmentComponent());
 						attachmentComponent.Actor = this;
 						attachmentComponent.UserId = Attachment.UserId;
-						attachmentComponent.Transform = this.Transform;
-						attachmentComponent.UpdateScale = false;
-						attachmentComponent.RemotePath = attachmentComponent.GetPathTo(this);
 
+						attachmentComponent.Transform = this.Transform;
 						hostAppUser.BeforeAvatarDestroyed += UserInfo_BeforeAvatarDestroyed;
 						return true;
 					}

--- a/MREGodotRuntimeLib/Core/Components/MREAttachmentComponent.cs
+++ b/MREGodotRuntimeLib/Core/Components/MREAttachmentComponent.cs
@@ -9,10 +9,17 @@ using Godot;
 
 namespace MixedRealityExtension.Core.Components
 {
-	internal class MREAttachmentComponent : RemoteTransform
+	internal class MREAttachmentComponent : Spatial
 	{
 		public Guid UserId { get; set; }
 
 		public Actor Actor { get; set; }
+
+		public override void _Process(float delta)
+		{
+			var scale = Actor.Scale;
+			Actor.GlobalTransform = GlobalTransform;
+			Actor.Scale = scale;
+		}
 	}
 }


### PR DESCRIPTION
When the server is not at the zero position, the RemoteTransform doesn't
work as expected.(it doesn't seem to respect rotation.)

The transform of attachment will be updated manually in `_process()`.