### PR TITLE
runtime: change user node from ARVROrigin to ARVRCamera

### DIFF
--- a/MREGodotRuntime/Scenes/Player.tscn
+++ b/MREGodotRuntime/Scenes/Player.tscn
@@ -9,11 +9,10 @@
 [ext_resource path="res://MREGodotRuntime/Scenes/Joystick2D.tscn" type="PackedScene" id=7]
 
 [sub_resource type="CapsuleShape" id=1]
-radius = 0.0563646
-height = 0.0459115
+radius = 0.0833106
+height = 0.0412165
 
 [node name="Player" type="ARVROrigin"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.69584, 0 )
 script = ExtResource( 2 )
 
 [node name="Configuration" type="Node" parent="."]
@@ -23,12 +22,18 @@ script = ExtResource( 1 )
 current = true
 script = ExtResource( 3 )
 
-[node name="CollisionShape" type="CollisionShape" parent="."]
+[node name="Area" type="Area" parent="MainCamera"]
+
+[node name="CollisionShape" type="CollisionShape" parent="MainCamera/Area"]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0, 0 )
 shape = SubResource( 1 )
 disabled = true
 
-[node name="socket-head" type="Spatial" parent="."]
+[node name="RightHand" parent="MainCamera" instance=ExtResource( 4 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0809927, -0.00564086, -0.150688 )
+visible = false
+
+[node name="socket-head" type="Spatial" parent="MainCamera"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.02003, -0.428197 )
 
 [node name="OpenXRLeftHand" parent="." instance=ExtResource( 6 )]
@@ -49,9 +54,5 @@ hand = 0
 [node name="OmniLight" type="OmniLight" parent="OpenXRRightHand"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.524409, 0.210365 )
 omni_range = 2.0
-
-[node name="RightHand" parent="." instance=ExtResource( 4 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0809927, -0.006109, -0.150688 )
-visible = false
 
 [node name="Joystick2D" parent="." instance=ExtResource( 7 )]

--- a/MREGodotRuntime/Scenes/Standalone.tscn
+++ b/MREGodotRuntime/Scenes/Standalone.tscn
@@ -7,15 +7,15 @@
 [node name="Spatial" type="Spatial"]
 
 [node name="MRENode" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -1.996 )
 script = ExtResource( 1 )
+MREURL = "ws://localhost:3901"
 SessionID = "testbed"
-AppID = "helloworld"
 EphemeralAppID = "helloworld-temp"
 UserNode = NodePath("../Player")
-MREURL = "ws://localhost:3901"
+AppID = "helloworld"
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.334629, 2.2771 )
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="."]
 environment = ExtResource( 3 )

--- a/MREGodotRuntime/Scripts/Joystick2D.cs
+++ b/MREGodotRuntime/Scripts/Joystick2D.cs
@@ -40,7 +40,7 @@ public class Joystick2D : TouchScreenButton
     public override void _Process(float delta)
     {
         var d = playerDirection * speed;
-        player.Translation += player.Transform.basis.x * d.x;
-        player.Translation += player.Transform.basis.z * d.y;
+        player.MainCamera.Translation += player.MainCamera.Transform.basis.x * d.x;
+        player.MainCamera.Translation += player.MainCamera.Transform.basis.z * d.y;
     }
 }

--- a/MREGodotRuntime/Scripts/LaunchMRE.cs
+++ b/MREGodotRuntime/Scripts/LaunchMRE.cs
@@ -104,7 +104,7 @@ public class LaunchMRE : Spatial
 		MREComponent.AutoJoin = AutoJoin;
 		MREComponent.GrantedPermissions = (MixedRealityExtension.Core.Permissions)(-1);
 		MREComponent.UserProperties = new MREComponent.UserProperty[0];
-		MREComponent.UserNode = GetNode(UserNode);
+		MREComponent.UserNode = GetNode(UserNode + "/MainCamera");
 		MREComponent.DialogFactory = GetNode<DialogFactory>("Player/DialogFactory");
 		AddChild(MREComponent);
 	}

--- a/MREGodotRuntime/Scripts/Player.cs
+++ b/MREGodotRuntime/Scripts/Player.cs
@@ -16,6 +16,7 @@ public class Player : ARVROrigin
     public Spatial Hand { get; private set;  }
     public Spatial ThumbTip { get; private set; }
     public Spatial IndexTip { get; private set; }
+    public Camera MainCamera { get; private set; }
 
     private bool InitializeOpenXR()
     {
@@ -23,6 +24,9 @@ public class Player : ARVROrigin
         if (ARVRInterface?.Initialize() == true)
         {
             GD.Print("OpenXR Interface initialized");
+
+            //default height 1.6m
+            MainCamera.Translation = Vector3.Up * 1.6f;
 
             Viewport vp = null;
             if (viewport != null)
@@ -44,10 +48,13 @@ public class Player : ARVROrigin
 
     public override void _EnterTree()
     {
-        InitializeOpenXR();
+        MainCamera = GetNode<Camera>("MainCamera");
         var openXRRightHand = GetNode<Spatial>("OpenXRRightHand");
         var openXRLeftHand = GetNode<Spatial>("OpenXRLeftHand");
-        var rightHand = GetNode<Spatial>("RightHand");
+        var rightHand = MainCamera.GetNode<Spatial>("RightHand");
+
+        InitializeOpenXR();
+
         if (ARVRInterfaceIsInitialized)
         {
             ThumbTip = openXRRightHand.FindNode("ThumbTip") as Spatial;
@@ -83,7 +90,7 @@ public class Player : ARVROrigin
             worldEnvironment.Environment.BackgroundMode = Godot.Environment.BGMode.Color;
             worldEnvironment.Environment.BackgroundColor = new Color(0, 0, 0, 0);
             GetTree().Root.TransparentBg = true;
-       }
+        }
     }
 
     public override void _PhysicsProcess(float delta)
@@ -94,19 +101,19 @@ public class Player : ARVROrigin
 
         if (Input.IsActionPressed("move_right"))
         {
-            Translation += Transform.basis.x * delta * speed;
+            MainCamera.Translation += MainCamera.Transform.basis.x * delta * speed;
         }
         else if (Input.IsActionPressed("move_left"))
         {
-            Translation -= Transform.basis.x * delta * speed;
+            MainCamera.Translation -= MainCamera.Transform.basis.x * delta * speed;
         }
         if (Input.IsActionPressed("move_back"))
         {
-            Translation += Transform.basis.z * delta * speed;
+            MainCamera.Translation += MainCamera.Transform.basis.z * delta * speed;
         }
         else if (Input.IsActionPressed("move_forward"))
         {
-            Translation -= Transform.basis.z * delta * speed;
+            MainCamera.Translation -= MainCamera.Transform.basis.z * delta * speed;
         }
 
         if (Input.IsActionPressed("shift"))
@@ -115,10 +122,10 @@ public class Player : ARVROrigin
         }
         else
         {
-            var newRotation = Rotation;
+            var newRotation = MainCamera.Rotation;
             newRotation.x -= mouseDelta.y * cameraSpeed;
             newRotation.y -= mouseDelta.x * cameraSpeed;
-            Rotation = newRotation;
+            MainCamera.Rotation = newRotation;
         }
         mouseDelta = Vector2.Zero;
     }

--- a/MREGodotRuntime/Scripts/Player/InputSource.cs
+++ b/MREGodotRuntime/Scripts/Player/InputSource.cs
@@ -175,11 +175,7 @@ namespace Assets.Scripts.User
 
 		public override void _EnterTree()
 		{
-			UserNode = Owner;
-			if (UserNode == null)
-			{
-				throw new Exception("Input source must have a MWUnityUser assigned to it.");
-			}
+			UserNode = this;
 		}
 
 		public override void _Process(float delta)


### PR DESCRIPTION
On openxr, the head transform changes the transform of `ARVRCamera`.
So, mre user node should be `ARVRCAmera` intead of `ARVROrigin`