### PR TITLE
runtime: remove Environment node from standalon scene

### DIFF
--- a/MREGodotRuntime/Scenes/Player.tscn
+++ b/MREGodotRuntime/Scenes/Player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/godot-openxr/OpenXRConfig.gdns" type="Script" id=1]
 [ext_resource path="res://MREGodotRuntime/Scripts/Player.cs" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://addons/godot-openxr/scenes/right_hand_nodes.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/godot-openxr/scenes/left_hand_nodes.tscn" type="PackedScene" id=6]
 [ext_resource path="res://MREGodotRuntime/Scenes/Joystick2D.tscn" type="PackedScene" id=7]
+[ext_resource path="res://default_env.tres" type="Environment" id=8]
 
 [sub_resource type="CapsuleShape" id=1]
 radius = 0.0563646
@@ -20,6 +21,7 @@ script = ExtResource( 2 )
 script = ExtResource( 1 )
 
 [node name="MainCamera" type="ARVRCamera" parent="."]
+environment = ExtResource( 8 )
 current = true
 script = ExtResource( 3 )
 

--- a/MREGodotRuntime/Scenes/Standalone.tscn
+++ b/MREGodotRuntime/Scenes/Standalone.tscn
@@ -1,21 +1,16 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://MREGodotRuntime/Scripts/LaunchMRE.cs" type="Script" id=1]
 [ext_resource path="res://MREGodotRuntime/Scenes/Player.tscn" type="PackedScene" id=2]
-[ext_resource path="res://default_env.tres" type="Environment" id=3]
 
 [node name="Spatial" type="Spatial"]
 
 [node name="MRENode" type="Spatial" parent="."]
 script = ExtResource( 1 )
 SessionID = "testbed"
+MREURL = "ws://localhost:3901"
+UserNode = NodePath("../Player")
 AppID = "helloworld"
 EphemeralAppID = "helloworld-temp"
-UserNode = NodePath("../Player")
-MREURL = "ws://localhost:3901"
 
 [node name="Player" parent="." instance=ExtResource( 2 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.334629, 2.2771 )
-
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = ExtResource( 3 )

--- a/MREGodotRuntime/Scripts/Player.cs
+++ b/MREGodotRuntime/Scripts/Player.cs
@@ -16,6 +16,7 @@ public class Player : ARVROrigin
     public Spatial Hand { get; private set;  }
     public Spatial ThumbTip { get; private set; }
     public Spatial IndexTip { get; private set; }
+    public Camera MainCamera { get; private set; }
 
     private bool InitializeOpenXR()
     {
@@ -44,6 +45,7 @@ public class Player : ARVROrigin
 
     public override void _EnterTree()
     {
+        MainCamera = GetNode<Camera>("MainCamera");
         InitializeOpenXR();
         var openXRRightHand = GetNode<Spatial>("OpenXRRightHand");
         var openXRLeftHand = GetNode<Spatial>("OpenXRLeftHand");
@@ -79,9 +81,7 @@ public class Player : ARVROrigin
     {
         if (ARVRInterfaceIsInitialized)
         {
-            var worldEnvironment = GetNode<WorldEnvironment>("../WorldEnvironment");
-            worldEnvironment.Environment.BackgroundMode = Godot.Environment.BGMode.Color;
-            worldEnvironment.Environment.BackgroundColor = new Color(0, 0, 0, 0);
+            MainCamera.Environment = ResourceLoader.Load<Environment>("res://MREGodotRuntime/arvr_env.tres");
             GetTree().Root.TransparentBg = true;
        }
     }

--- a/MREGodotRuntime/arvr_env.tres
+++ b/MREGodotRuntime/arvr_env.tres
@@ -1,0 +1,7 @@
+[gd_resource type="Environment" load_steps=2 format=2]
+
+[sub_resource type="ProceduralSky" id=1]
+
+[resource]
+background_mode = 1
+background_sky = SubResource( 1 )


### PR DESCRIPTION
Instead, it uses Environment property of MainCamera node.