### PR TITLE
toolkit: remove internal component dependencies

### DIFF
--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -59,7 +59,7 @@ namespace MixedRealityExtension.Core
 		private GodotCollisionShape _collider;
 		private ColliderPatch _pendingColliderPatch;
 		private LookAtComponent _lookAt;
-		private ClippingComponent _clipping;
+		private ClippingBase _clipping;
 		class MediaInstance
 		{
 			public Guid MediaAssetId { get; }
@@ -1726,7 +1726,8 @@ namespace MixedRealityExtension.Core
 			{
 				if (_clipping == null)
 				{
-					_clipping = GetOrCreateActorComponent<ClippingComponent>();
+					_clipping = new ClippingBox();
+					AddChild(_clipping);
 				}
 				_clipping.ApplyPatch(clippingPatch);
 			}

--- a/MREGodotRuntimeLib/Core/ClippingBox.cs
+++ b/MREGodotRuntimeLib/Core/ClippingBox.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Samsung Electronics Co., Ltd. All rights reserved.
+// Licensed under the MIT License.
+
+using Godot;
+
+namespace MixedRealityExtension.Core
+{
+	internal class ClippingBox : ClippingBase
+	{
+		private static Vector3 Vector3Half = Vector3.One * 0.5f;
+
+		public override void _Process(float delta)
+		{
+			var globalTransform = GlobalTransform;
+			globalTransform.basis = globalTransform.basis.Scaled(Vector3Half);
+			var affineInverse = globalTransform.AffineInverse();
+			foreach (var shaderMaterial in ShaderMaterials())
+			{
+				shaderMaterial.SetShaderParam("clipBoxInverseTransform", affineInverse);
+			}
+		}
+
+		public override void ClearMeshInstances()
+		{
+			base.ClearMeshInstances();
+			foreach (var shaderMaterial in ShaderMaterials())
+			{
+				// clear inverse transform matrix
+				shaderMaterial.SetShaderParam("clipBoxInverseTransform", null);
+			}
+		}
+	}
+}

--- a/MREGodotRuntimeLib/Core/TouchablePlane.cs
+++ b/MREGodotRuntimeLib/Core/TouchablePlane.cs
@@ -70,6 +70,29 @@ namespace MixedRealityExtension.Core
 		/// </summary>
 		public Vector3 LocalPressDirection => LocalForward;
 
+		/// <inheritdoc/>
+		public CollisionShape TouchableBoxShape
+		{
+			get => touchableBoxShape;
+			set {
+				if (touchableBoxShape == value)
+					return;
+
+				if (value != null && value.Shape is BoxShape boxShape)
+				{
+					touchableBoxShape = value;
+					// Set x and y center to match the newCollider but change the position of the
+					// z axis so the plane is always in front of the object
+					SetLocalCenter(touchableBoxShape.Transform.origin + LocalForward * boxShape.Extents);
+				}
+				else
+				{
+					GD.PushWarning("TouchableBoxShape is not BoxShape, cannot set TouchableBoxShape.");
+				}
+			}
+		}
+
+		private CollisionShape touchableBoxShape;
 		private Spatial ParentActor;
 
 		public TouchablePlane(Actor actor)
@@ -122,27 +145,6 @@ namespace MixedRealityExtension.Core
 			LocalCenter = newLocalCenter;
 		}
 
-		/// <summary>
-		/// Adjust the bounds, local center and local forward to match a given box collider.  This method
-		/// also changes the size of the box collider attached to the actor.
-		/// Default Behavior:  if touchableCollider is null at runtime, the object's box collider will be used
-		/// to size and place the TouchablePlane in front of the actor
-		/// </summary>
-		public void SetTouchableCollisionShape(CollisionObject collisionObject)
-		{
-			CollisionShape collisionShape = collisionObject.GetChild<CollisionShape>();
-			if (collisionShape != null && collisionShape.Shape is BoxShape boxShape)
-			{
-				// Set x and y center to match the newCollider but change the position of the
-				// z axis so the plane is always in front of the object
-				SetLocalCenter(collisionShape.Transform.origin + LocalForward * boxShape.Extents);
-			}
-			else
-			{
-				GD.PushWarning("BoxCollider is null, cannot set bounds of TouchableComponent");
-			}
-		}
-
 		/// <inheritdoc />
 		public float DistanceToTouchable(Vector3 samplePoint, out Vector3 normal)
 		{
@@ -188,7 +190,7 @@ namespace MixedRealityExtension.Core
 			var collisionObject = ParentActor.GetChild<CollisionObject>();
 			if (collisionObject != null)
 			{
-				SetTouchableCollisionShape(collisionObject);
+				TouchableBoxShape = collisionObject.GetChild<CollisionShape>();
 			}
 
 			ValidateProperties();

--- a/MREGodotRuntimeLib/PluginInterfaces/ITouchableSurface.cs
+++ b/MREGodotRuntimeLib/PluginInterfaces/ITouchableSurface.cs
@@ -16,5 +16,10 @@ namespace MixedRealityExtension.PluginInterfaces
 		/// This is the direction that a user will press on this element.
 		/// </summary>
 		Vector3 LocalPressDirection { get; }
+
+		/// <summary>
+		/// local center and local forward are adjusted to match a this collision shape.
+		/// </summary>
+		CollisionShape TouchableBoxShape { get; set; }
 	}
 }

--- a/Toolkit/PressableButtonGodot.cs
+++ b/Toolkit/PressableButtonGodot.cs
@@ -179,7 +179,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 		{
 			if (toolkitPatch is ButtonPatch patch)
 			{
-				((TouchablePlane)touchableSurface).SetLocalCenter(new Vector3(0, 0, 0.016f));
+				touchableSurface.TouchableBoxShape = GetNode<CollisionShape>("TouchableArea/CollisionShape");
 				ApplyText(patch.MainText);
 				ApplyColor(patch.Color);
 			}

--- a/Toolkit/ScrollingObjectCollection.cs
+++ b/Toolkit/ScrollingObjectCollection.cs
@@ -17,6 +17,7 @@ using MixedRealityExtension.Patching.Types;
 using MixedRealityExtension.Core.Components;
 using MixedRealityExtension.Behaviors.Actions;
 using MixedRealityExtension.Core.Interfaces;
+using MixedRealityExtension.PluginInterfaces;
 
 namespace Microsoft.MixedReality.Toolkit.UI
 {
@@ -395,7 +396,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// <summary>
         /// Scrolling interaction touchable used to catch touch events on empty spaces.
         /// </summary>
-        internal TouchablePlane ScrollingTouchable { get; private set; }
+        internal ITouchableSurface ScrollingTouchable { get; private set; }
 
         // The empty Spatial that contains our nodes and be scrolled
         private Spatial scrollContainer;
@@ -649,15 +650,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 ScrollingCollisionBoxShape.Extents = new Vector3(CellWidth * TiersPerPage * 0.5f, CellHeight * CellsPerTier * 0.5f, ScrollingColliderDepth);
             }
 
-            Vector3 colliderPosition;
-            colliderPosition.x = ScrollingCollisionBoxShape.Extents.x / 2;
-            colliderPosition.y = -ScrollingCollisionBoxShape.Extents.y / 2;
-            colliderPosition.z = cellDepth / 2 + ScrollingColliderDepth;
-
-            Vector3 touchablePosition = colliderPosition;
-            touchablePosition.z = -cellDepth / 2;
-
-            ScrollingTouchable.SetLocalCenter(touchablePosition);
+            ScrollingTouchable.TouchableBoxShape = GetNode<CollisionShape>("CollisionShape");
         }
 
         /// <summary>
@@ -1897,7 +1890,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             if (toolkitPatch is ScrollingObjectCollectionPatch patch)
             {
-                ScrollingTouchable = Parent.GetChild<TouchablePlane>();
+                ScrollingTouchable = Parent.GetChild<ITouchableSurface>();
                 var actor = Parent as IActor;
                 foreach (var scrollContent in patch.ScrollContents)
                 {

--- a/Toolkit/ScrollingObjectCollection.cs
+++ b/Toolkit/ScrollingObjectCollection.cs
@@ -427,28 +427,28 @@ namespace Microsoft.MixedReality.Toolkit.UI
             }
         }
 
-        private ClippingComponent clippingComponent;
+        private ClippingBase clippingBase;
 
         /// <summary>
         /// The ScrollingObjectCollection's ClippingBox.
         /// that is used for clipping items in and out of the list.
         /// </summary>
-        internal ClippingComponent ClippingComponent
+        internal ClippingBase ClippingBase
         {
             get
             {
-                if (clippingComponent == null)
+                if (clippingBase == null)
                 {
-                    ClippingComponent oldClippingComponent = Parent.GetChild<ClippingComponent>();
+                    ClippingBase oldClippingComponent = Parent.GetChild<ClippingBase>();
 
                     if (oldClippingComponent != null)
                     {
-                        clippingComponent = oldClippingComponent;
+                        clippingBase = oldClippingComponent;
                     }
-                    clippingComponent.Transform = Transform.Identity;
+                    clippingBase.Transform = Transform.Identity;
                 }
 
-                return clippingComponent;
+                return clippingBase;
             }
         }
 
@@ -671,19 +671,19 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
                     // Apply the viewable area and column/row multiplier
                     // Use a dummy bounds of one to get the local scale to match;
-                    ClippingComponent.Scale = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, CellDepth);
+                    ClippingBase.Scale = new Vector3(CellWidth * CellsPerTier, CellHeight * TiersPerPage, CellDepth);
 
                     break;
 
                 case ScrollDirectionType.LeftAndRight:
 
                     // Same as above for L <-> R
-                    ClippingComponent.Scale = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, CellDepth);
+                    ClippingBase.Scale = new Vector3(CellWidth * TiersPerPage, CellHeight * CellsPerTier, CellDepth);
 
                     break;
             }
             // Apply new values
-            ClippingComponent.Transform = new Transform(ClippingComponent.Transform.basis, Vector3.Zero);
+            ClippingBase.Transform = new Transform(ClippingBase.Transform.basis, Vector3.Zero);
         }
 
         #endregion Setup methods
@@ -1283,16 +1283,16 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private bool DetectScrollRelease(Vector3 pointerPos)
         {
-            Vector3 scrollToPointerVector = pointerPos - ClippingComponent.GlobalTransform.origin;
+            Vector3 scrollToPointerVector = pointerPos - ClippingBase.GlobalTransform.origin;
 
             // Projecting vector onto every clip box space coordinate and using clip box lossy scale as reference to dimensions to scroll view visible bounds
             // Using dot product to check if pointer is in front or behind the scroll view plane
-            bool isScrollRelease = scrollToPointerVector.Project(ClippingComponent.GlobalTransform.basis.y).Length() > ClippingComponent.GlobalTransform.basis.Scale.y / 2 + ReleaseThresholdTopBottom
-                                || scrollToPointerVector.Project(ClippingComponent.GlobalTransform.basis.x).Length() > ClippingComponent.GlobalTransform.basis.Scale.x / 2 + ReleaseThresholdLeftRight
+            bool isScrollRelease = scrollToPointerVector.Project(ClippingBase.GlobalTransform.basis.y).Length() > ClippingBase.GlobalTransform.basis.Scale.y / 2 + ReleaseThresholdTopBottom
+                                || scrollToPointerVector.Project(ClippingBase.GlobalTransform.basis.x).Length() > ClippingBase.GlobalTransform.basis.Scale.x / 2 + ReleaseThresholdLeftRight
 
                                 || (scrollToPointerVector.Dot(-GlobalTransform.basis.z) > 0 ?
-                                        scrollToPointerVector.Project(-ClippingComponent.GlobalTransform.basis.z).Length() > ClippingComponent.GlobalTransform.basis.Scale.z / 2 + ReleaseThresholdBack :
-                                        scrollToPointerVector.Project(-ClippingComponent.GlobalTransform.basis.z).Length() > ClippingComponent.GlobalTransform.basis.Scale.z / 2 + ReleaseThresholdFront);
+                                        scrollToPointerVector.Project(-ClippingBase.GlobalTransform.basis.z).Length() > ClippingBase.GlobalTransform.basis.Scale.z / 2 + ReleaseThresholdBack :
+                                        scrollToPointerVector.Project(-ClippingBase.GlobalTransform.basis.z).Length() > ClippingBase.GlobalTransform.basis.Scale.z / 2 + ReleaseThresholdFront);
             return isScrollRelease;
         }
 
@@ -1303,7 +1303,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             foreach (var meshInstance in meshInstances)
             {
-                ClippingComponent.AddMeshInstance(meshInstance);
+                ClippingBase.AddMeshInstance(meshInstance);
             }
         }
 
@@ -1314,7 +1314,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         {
             foreach (var meshInstance in meshInstances)
             {
-                ClippingComponent.RemoveMeshInstance(meshInstance);
+                ClippingBase.RemoveMeshInstance(meshInstance);
             }
         }
 
@@ -1323,7 +1323,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
         /// </summary>
         private void ClearClippingBox()
         {
-            ClippingComponent.ClearMeshInstances();
+            ClippingBase.ClearMeshInstances();
         }
 
         /// <summary>
@@ -1350,10 +1350,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
                 return;
             }
 
-            AABB clippingThresholdAABB = ClippingComponent.Bounds;
+            AABB clippingThresholdAABB = ClippingBase.Bounds;
             var contentMeshInstances = ScrollContainer.GetChildrenAll<MeshInstance>();
             clippedMeshInstances.Clear();
-            clippedMeshInstances.UnionWith(ClippingComponent.GetNodesCopy());
+            clippedMeshInstances.UnionWith(ClippingBase.GetNodesCopy());
             clippedActors.Clear();
 
             // Remove all renderers from clipping primitive that are not part of scroll content
@@ -1425,7 +1425,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 
             // Check collider visibility
             // Outer clipping bounds is used to ensure collider has minimum visibility to stay enabled
-            AABB outerClippingThresholdBounds = ClippingComponent.Bounds;
+            AABB outerClippingThresholdBounds = ClippingBase.Bounds;
             outerClippingThresholdBounds.Size *= contentVisibilityThresholdRatio;
 
             var collisionShapes = ScrollContainer.GetChildrenAll<CollisionShape>();


### PR DESCRIPTION
Since `ActorComponent` is internal, we cannot use it in toolkit package. instead, use public interfaces. 