### PR TITLE
toolkit: introduce text class for toolkit

### DIFF
--- a/Toolkit/PressableButtonGodot.cs
+++ b/Toolkit/PressableButtonGodot.cs
@@ -29,7 +29,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 		private MeshInstance HighlightPlate;
 		private ShaderMaterial BackPlateMaterial => (ShaderMaterial)BackPlate.MaterialOverride;
 		private ShaderMaterial HighlightPlateMaterial => (ShaderMaterial)HighlightPlate.MaterialOverride;
-		private SimpleText TextNode;
+		private ToolkitText textNode;
 		private Vector3 initialLocalScale;
 		private MWAction _touchAction = new MWAction();
 		private IUser currentUser;
@@ -67,12 +67,10 @@ namespace Microsoft.MixedReality.Toolkit.UI
 			HighlightPlate = movingButtonVisuals.GetNode<MeshInstance>("HighlightPlate");
 			HighlightPlate.MaterialOverride = HighlightPlate.MaterialOverride.Duplicate(true) as ShaderMaterial;
 
-			TextNode = GetNode<SimpleText>("Text");
-			TextNode.Contents = text;
-			TextNode.Anchor = MixedRealityExtension.Core.Interfaces.TextAnchorLocation.MiddleCenter;
-			TextNode.Height = 0.2f;
-			TextNode.Transform = new Transform(TextNode.Transform.basis, ToLocal(HighlightPlate.GlobalTransform.origin) / 2);
-			TextNode.Scale = new Vector3(0.032f, 0.032f, 0.032f);
+			textNode = GetNode<ToolkitText>("ToolkitText");
+			textNode.Text = text;
+			textNode.Transform = new Transform(textNode.Transform.basis, ToLocal(HighlightPlate.GlobalTransform.origin) / 2);
+			textNode.Scale = new Vector3(0.02f, 0.02f, 0.02f);
 		}
 
 		public override void _PhysicsProcess(float delta)
@@ -80,12 +78,12 @@ namespace Microsoft.MixedReality.Toolkit.UI
 			if (IsTouching && IsPressing)
 			{
 				PulseProximityLight(delta);
-				TextNode.Transform = new Transform(TextNode.Transform.basis, ToLocal(GlobalTransform.basis.z.Normalized() * 0.001f + GlobalTransform.origin));
+				textNode.Transform = new Transform(textNode.Transform.basis, ToLocal(GlobalTransform.basis.z.Normalized() * 0.001f + GlobalTransform.origin));
 			}
 			else
 			{
 				RevertProximityLight();
-				TextNode.Transform = new Transform(TextNode.Transform.basis, ToLocal(HighlightPlate.GlobalTransform.origin) / 2);
+				textNode.Transform = new Transform(textNode.Transform.basis, ToLocal(HighlightPlate.GlobalTransform.origin) / 2);
 			}
 		}
 
@@ -131,7 +129,7 @@ namespace Microsoft.MixedReality.Toolkit.UI
 		internal void ApplyText(string text)
 		{
 			if (text == null) return;
-			TextNode.Contents = text;
+			textNode.Text = text;
 		}
 
 		public virtual void OnFocusEnter(Spatial inputSource, Node userNode, Spatial oldTarget, Spatial newTarget)

--- a/Toolkit/PressableButtonGodot.tscn
+++ b/Toolkit/PressableButtonGodot.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=13 format=2]
 
-[ext_resource path="res://MREGodotRuntime/Scripts/SimpleText.cs" type="Script" id=1]
+[ext_resource path="res://Toolkit/ToolkitText.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Toolkit/PressableButtonGodot.cs" type="Script" id=4]
 
 [sub_resource type="Shader" id=1]
@@ -100,10 +100,10 @@ shader_param/clipBoxInverseTransform = null
 
 [sub_resource type="QuadMesh" id=6]
 
-[sub_resource type="BoxShape" id=8]
+[sub_resource type="BoxShape" id=7]
 extents = Vector3( 0.5, 0.5, 0.5 )
 
-[sub_resource type="Shader" id=9]
+[sub_resource type="Shader" id=8]
 code = "shader_type spatial;
 render_mode unshaded;
 
@@ -136,13 +136,13 @@ void fragment()
 	ALPHA = PointVsBox(global_vertex, clipBoxInverseTransform);
 }"
 
-[sub_resource type="ShaderMaterial" id=10]
-shader = SubResource( 9 )
+[sub_resource type="ShaderMaterial" id=9]
+shader = SubResource( 8 )
 shader_param/color = Color( 0.086, 0.2, 0.5, 1 )
 shader_param/border = 0.02
 shader_param/clipBoxInverseTransform = null
 
-[sub_resource type="QuadMesh" id=11]
+[sub_resource type="QuadMesh" id=10]
 
 [node name="PressableButtonGodot" type="Spatial"]
 script = ExtResource( 4 )
@@ -168,13 +168,12 @@ collision_mask = 0
 
 [node name="CollisionShape" type="CollisionShape" parent="TouchableArea"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -0.5 )
-shape = SubResource( 8 )
+shape = SubResource( 7 )
 
 [node name="BackPlate" type="MeshInstance" parent="."]
 transform = Transform( 0.032, 0, 0, 0, 0.032, 0, 0, 0, 0.01, 0, 0, 0 )
-material_override = SubResource( 10 )
-mesh = SubResource( 11 )
+material_override = SubResource( 9 )
+mesh = SubResource( 10 )
 material/0 = null
 
-[node name="Text" type="MeshInstance" parent="."]
-script = ExtResource( 1 )
+[node name="ToolkitText" parent="." instance=ExtResource( 1 )]

--- a/Toolkit/ToolkitText.cs
+++ b/Toolkit/ToolkitText.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Samsung Electronics Co., Ltd. All rights reserved.
+// Licensed under the MIT License.
+
+using Godot;
+
+namespace Microsoft.MixedReality.Toolkit.UI
+{
+	public class ToolkitText : Sprite3D
+	{
+		private Viewport viewport;
+		private Label label;
+
+		public string Text {
+			get => label.Text;
+			set
+			{
+				label.Text = value;
+				label.Hide();
+				label.Show();
+				viewport.Size = label.RectSize;
+				var viewportTexture = viewport.GetTexture();
+				viewportTexture.Flags = (uint)Texture.FlagsEnum.Filter;
+				Texture = viewportTexture;
+			}
+		}
+
+		public override void _Ready()
+		{
+			viewport = GetNode<Viewport>("Viewport");
+			label = viewport.GetNode<Label>("Label");
+		}
+	}
+}

--- a/Toolkit/ToolkitText.tscn
+++ b/Toolkit/ToolkitText.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://MREGodotRuntime/Scripts/Fonts/NanumSquareRound/NanumSquareRoundR.ttf" type="DynamicFontData" id=2]
+[ext_resource path="res://Toolkit/ToolkitText.cs" type="Script" id=3]
+
+[sub_resource type="DynamicFont" id=1]
+size = 64
+font_data = ExtResource( 2 )
+
+[sub_resource type="Theme" id=2]
+default_font = SubResource( 1 )
+
+[node name="ToolkitText" type="Sprite3D"]
+flip_v = true
+script = ExtResource( 3 )
+
+[node name="Viewport" type="Viewport" parent="."]
+transparent_bg = true
+render_target_update_mode = 3
+
+[node name="Label" type="Label" parent="Viewport"]
+margin_bottom = 72.0
+theme = SubResource( 2 )


### PR DESCRIPTION
The `ToolkitText` class replaces `SimpleText` from `MREGodotRuntime`.

This patch removes the dependency of Runtime form Toolkit pacakges.