### PR TITLE
lib: initialize actor via script instance instead of its relative file path

### DIFF
--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -37,16 +37,14 @@ namespace MixedRealityExtension.Core
 	/// </summary>
 	internal sealed class Actor : MixedRealityExtensionObject, ICommandHandlerContext, IActor
 	{
-		//FIXME: need to change path
-		private static Resource Resource = ResourceLoader.Load("MREGodotRuntimeLib/Core/Actor.cs");
+		private static readonly Reference actorScript = new Actor().GetScript();
 
 		public static Actor Instantiate(Spatial node3D)
 		{
-			var parent = node3D.GetParent();
 			ulong objId = node3D.GetInstanceId();
 			var name = node3D.Name;
 
-			node3D.SetScript(Resource);
+			node3D.SetScript(actorScript);
 			var newNode = GD.InstanceFromId(objId) as Actor;
 			newNode.Name = name;
 			newNode.SetProcess(true);

--- a/MREGodotRuntimeLib/Core/Collider.cs
+++ b/MREGodotRuntimeLib/Core/Collider.cs
@@ -63,15 +63,14 @@ namespace MixedRealityExtension.Core
 
 	internal class Collider : Area, ICollider
 	{
-		//FIXME: need to change path
-		private static Resource Resource = ResourceLoader.Load("MREGodotRuntimeLib/Core/Collider.cs");
+		private static readonly Reference colliderScript = new Collider().GetScript();
 
 		public static Collider Instantiate(Area area)
 		{
 			var parent = area.GetParent();
 			ulong objId = area.GetInstanceId();
 
-			area.SetScript(Resource);
+			area.SetScript(colliderScript);
 			var newArea = GD.InstanceFromId(objId) as Collider;
 			newArea.SetProcess(true);
 			return newArea;


### PR DESCRIPTION
When MRE is compiled with runtime into the same package, there are no
problems loading script via relative path. but, if you use MRE DLL that contains
compiled cs files, script is not loaded because there are no cs files.

I thought using relative path was the only way, but it turns out that i can get
script from an instance.
I hope it works the same as before.. i couldn't find any issues in my tests.