### PR TITLE
lib: make procedualtoolkit classes internal

### DIFF
--- a/MREGodotRuntimeLib/ProceduralToolkit/ArrayE.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/ArrayE.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Array extensions
 	/// </summary>
-	public static class ArrayE
+	internal static class ArrayE
 	{
 		/// <summary>
 		/// Gets the next or the first node in the <see cref="LinkedList{T}"/>

--- a/MREGodotRuntimeLib/ProceduralToolkit/Directions.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Directions.cs
@@ -6,7 +6,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Specifies directions along thee axes
 	/// </summary>
 	[Flags]
-	public enum Directions
+	internal enum Directions
 	{
 		None = 0,
 		Left = 1,
@@ -21,7 +21,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 		All = Left | Right | Down | Up | Back | Forward
 	}
 
-	public static class DirectionsExtensions
+	internal static class DirectionsExtensions
 	{
 		public static bool HasFlag(this Directions directions, Directions flag)
 		{

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Circle2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Circle2.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 2D circle
 	/// </summary>
 	[Serializable]
-	public struct Circle2 : IEquatable<Circle2>, IFormattable
+	internal struct Circle2 : IEquatable<Circle2>, IFormattable
 	{
 		public Vector2 center;
 		public float radius;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Circle3.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Circle3.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 3D circle
 	/// </summary>
 	[Serializable]
-	public struct Circle3 : IEquatable<Circle3>, IFormattable
+	internal struct Circle3 : IEquatable<Circle3>, IFormattable
 	{
 		public Vector3 center;
 		public Vector3 normal;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Closest2D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Closest2D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of closest point(s) algorithms
 	/// </summary>
-	public static partial class Closest
+	internal static partial class Closest
 	{
 		#region Point-Line
 
@@ -116,8 +116,8 @@ namespace MixedRealityExtension.ProceduralToolkit
 		/// <summary>
 		/// Projects the point onto the segment
 		/// </summary>
-		/// <param name="projectedX">Normalized position of the projected point on the segment. 
-		/// Value of zero means that the projected point coincides with segment.a. 
+		/// <param name="projectedX">Normalized position of the projected point on the segment.
+		/// Value of zero means that the projected point coincides with segment.a.
 		/// Value of one means that the projected point coincides with segment.b.</param>
 		public static Vector2 PointSegment(Vector2 point, Segment2 segment, out float projectedX)
 		{
@@ -136,8 +136,8 @@ namespace MixedRealityExtension.ProceduralToolkit
 		/// <summary>
 		/// Projects the point onto the segment
 		/// </summary>
-		/// <param name="projectedX">Normalized position of the projected point on the segment. 
-		/// Value of zero means that the projected point coincides with <paramref name="segmentA"/>. 
+		/// <param name="projectedX">Normalized position of the projected point on the segment.
+		/// Value of zero means that the projected point coincides with <paramref name="segmentA"/>.
 		/// Value of one means that the projected point coincides with <paramref name="segmentB"/>.</param>
 		public static Vector2 PointSegment(Vector2 point, Vector2 segmentA, Vector2 segmentB, out float projectedX)
 		{
@@ -323,7 +323,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			{
 				// Parallel
 				bool codirected = lineDirection.Dot(segmentDirection) > 0;
-				// Normalized direction gives more stable results 
+				// Normalized direction gives more stable results
 				float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 				if (Mathf.Abs(perpDotA) > Geometry.Epsilon || Mathf.Abs(perpDotB) > Geometry.Epsilon)
 				{
@@ -589,7 +589,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			Vector2 segmentAToOrigin = rayOrigin - segmentA;
 			float denominator = VectorE.PerpDot(rayDirection, segmentDirection);
 			float perpDotA = VectorE.PerpDot(rayDirection, segmentAToOrigin);
-			// Normalized direction gives more stable results 
+			// Normalized direction gives more stable results
 			float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 
 			if (Mathf.Abs(denominator) < Geometry.Epsilon)

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Closest3D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Closest3D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of closest point(s) algorithms
 	/// </summary>
-	public static partial class Closest
+	internal static partial class Closest
 	{
 		#region Point-Line
 
@@ -117,8 +117,8 @@ namespace MixedRealityExtension.ProceduralToolkit
 		/// <summary>
 		/// Projects the point onto the segment
 		/// </summary>
-		/// <param name="projectedX">Normalized position of the projected point on the segment. 
-		/// Value of zero means that the projected point coincides with segment.a. 
+		/// <param name="projectedX">Normalized position of the projected point on the segment.
+		/// Value of zero means that the projected point coincides with segment.a.
 		/// Value of one means that the projected point coincides with segment.b.</param>
 		public static Vector3 PointSegment(Vector3 point, Segment3 segment, out float projectedX)
 		{
@@ -137,8 +137,8 @@ namespace MixedRealityExtension.ProceduralToolkit
 		/// <summary>
 		/// Projects the point onto the segment
 		/// </summary>
-		/// <param name="projectedX">Normalized position of the projected point on the segment. 
-		/// Value of zero means that the projected point coincides with <paramref name="segmentA"/>. 
+		/// <param name="projectedX">Normalized position of the projected point on the segment.
+		/// Value of zero means that the projected point coincides with <paramref name="segmentA"/>.
 		/// Value of one means that the projected point coincides with <paramref name="segmentB"/>.</param>
 		public static Vector3 PointSegment(Vector3 point, Vector3 segmentA, Vector3 segmentB, out float projectedX)
 		{

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Distance2D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Distance2D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of distance calculation algorithms
 	/// </summary>
-	public static partial class Distance
+	internal static partial class Distance
 	{
 		#region Point-Line
 
@@ -216,7 +216,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			if (Mathf.Abs(denominator) < Geometry.Epsilon)
 			{
 				// Parallel
-				// Normalized direction gives more stable results 
+				// Normalized direction gives more stable results
 				float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 				if (Mathf.Abs(perpDotA) > Geometry.Epsilon || Mathf.Abs(perpDotB) > Geometry.Epsilon)
 				{
@@ -407,7 +407,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			Vector2 segmentDirection = segmentB - segmentA;
 			float denominator = VectorE.PerpDot(rayDirection, segmentDirection);
 			float perpDotA = VectorE.PerpDot(rayDirection, segmentAToOrigin);
-			// Normalized direction gives more stable results 
+			// Normalized direction gives more stable results
 			float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 
 			if (Mathf.Abs(denominator) < Geometry.Epsilon)

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Distance3D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Distance3D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of distance calculation algorithms
 	/// </summary>
-	public static partial class Distance
+	internal static partial class Distance
 	{
 		#region Point-Line
 

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Geometry.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Geometry.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Utility class for computational geometry algorithms
 	/// </summary>
-	public static class Geometry
+	internal static class Geometry
 	{
 		/// <summary>
 		/// A tiny floating point value used in comparisons

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersect2D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersect2D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of intersection algorithms
 	/// </summary>
-	public static partial class Intersect
+	internal static partial class Intersect
 	{
 		#region Point-Line
 
@@ -449,7 +449,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			if (Mathf.Abs(denominator) < Geometry.Epsilon)
 			{
 				// Parallel
-				// Normalized direction gives more stable results 
+				// Normalized direction gives more stable results
 				float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 				if (Mathf.Abs(perpDotA) > Geometry.Epsilon || Mathf.Abs(perpDotB) > Geometry.Epsilon)
 				{
@@ -685,7 +685,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 			Vector2 segmentDirection = segmentB - segmentA;
 			float denominator = VectorE.PerpDot(rayDirection, segmentDirection);
 			float perpDotA = VectorE.PerpDot(rayDirection, segmentAToOrigin);
-			// Normalized direction gives more stable results 
+			// Normalized direction gives more stable results
 			float perpDotB = VectorE.PerpDot(segmentDirection.Normalized(), segmentAToOrigin);
 
 			if (Mathf.Abs(denominator) < Geometry.Epsilon)

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersect3D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersect3D.cs
@@ -5,7 +5,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Collection of intersection algorithms
 	/// </summary>
-	public static partial class Intersect
+	internal static partial class Intersect
 	{
 		#region Point-Line
 

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/IntersectionType.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/IntersectionType.cs
@@ -1,6 +1,6 @@
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public enum IntersectionType : byte
+	internal enum IntersectionType : byte
 	{
 		None = 0,
 		Point,

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionCircleCircle.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionCircleCircle.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionCircleCircle
+	internal struct IntersectionCircleCircle
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineCircle.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineCircle.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionLineCircle
+	internal struct IntersectionLineCircle
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineLine2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineLine2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionLineLine2
+	internal struct IntersectionLineLine2
 	{
 		public IntersectionType type;
 		public Vector2 point;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineRay2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineRay2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionLineRay2
+	internal struct IntersectionLineRay2
 	{
 		public IntersectionType type;
 		public Vector2 point;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineSegment2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineSegment2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionLineSegment2
+	internal struct IntersectionLineSegment2
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineSphere.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionLineSphere.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionLineSphere
+	internal struct IntersectionLineSphere
 	{
 		public IntersectionType type;
 		public Vector3 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRayCircle.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRayCircle.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionRayCircle
+	internal struct IntersectionRayCircle
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRayRay2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRayRay2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionRayRay2
+	internal struct IntersectionRayRay2
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRaySegment2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRaySegment2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionRaySegment2
+	internal struct IntersectionRaySegment2
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRaySphere.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionRaySphere.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionRaySphere
+	internal struct IntersectionRaySphere
 	{
 		public IntersectionType type;
 		public Vector3 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentCircle.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentCircle.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionSegmentCircle
+	internal struct IntersectionSegmentCircle
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentSegment2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentSegment2.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionSegmentSegment2
+	internal struct IntersectionSegmentSegment2
 	{
 		public IntersectionType type;
 		public Vector2 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentSphere.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSegmentSphere.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionSegmentSphere
+	internal struct IntersectionSegmentSphere
 	{
 		public IntersectionType type;
 		public Vector3 pointA;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSphereSphere.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Intersections/IntersectionSphereSphere.cs
@@ -2,7 +2,7 @@ using Godot;
 
 namespace MixedRealityExtension.ProceduralToolkit
 {
-	public struct IntersectionSphereSphere
+	internal struct IntersectionSphereSphere
 	{
 		public IntersectionType type;
 		public Vector3 point;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Line2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Line2.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 2D line
 	/// </summary>
 	[Serializable]
-	public struct Line2 : IEquatable<Line2>, IFormattable
+	internal struct Line2 : IEquatable<Line2>, IFormattable
 	{
 		public Vector2 origin;
 		public Vector2 direction;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Line3.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Line3.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 3D line
 	/// </summary>
 	[Serializable]
-	public struct Line3 : IEquatable<Line3>, IFormattable
+	internal struct Line3 : IEquatable<Line3>, IFormattable
 	{
 		public Vector3 origin;
 		public Vector3 direction;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Segment2.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Segment2.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 2D line segment
 	/// </summary>
 	[Serializable]
-	public struct Segment2 : IEquatable<Segment2>, IFormattable
+	internal struct Segment2 : IEquatable<Segment2>, IFormattable
 	{
 		public Vector2 a;
 		public Vector2 b;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Segment3.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Segment3.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a 3D line segment
 	/// </summary>
 	[Serializable]
-	public struct Segment3 : IEquatable<Segment3>, IFormattable
+	internal struct Segment3 : IEquatable<Segment3>, IFormattable
 	{
 		public Vector3 a;
 		public Vector3 b;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Sphere.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/Sphere.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Representation of a sphere
 	/// </summary>
 	[Serializable]
-	public struct Sphere : IEquatable<Sphere>, IFormattable
+	internal struct Sphere : IEquatable<Sphere>, IFormattable
 	{
 		public Vector3 center;
 		public float radius;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/Plan.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/Plan.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit.Skeleton
 	/// <summary>
 	/// Representation of the active plan during generation process
 	/// </summary>
-	public class Plan : IEnumerable<Plan.Vertex>
+	internal class Plan : IEnumerable<Plan.Vertex>
 	{
 		public int Count { get { return vertices.Count; } }
 		public Vertex First { get { return vertices[0]; } }

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/StraightSkeleton.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/StraightSkeleton.cs
@@ -6,7 +6,7 @@ namespace MixedRealityExtension.ProceduralToolkit.Skeleton
 	/// <summary>
 	/// A straight skeleton representation
 	/// </summary>
-	public class StraightSkeleton
+	internal class StraightSkeleton
 	{
 		public List<List<Vector2>> polygons = new List<List<Vector2>>();
 

--- a/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/StraightSkeletonGenerator.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Geometry/StraightSkeleton/StraightSkeletonGenerator.cs
@@ -5,12 +5,12 @@ using Godot;
 namespace MixedRealityExtension.ProceduralToolkit.Skeleton
 {
 	/// <summary>
-	/// A straight skeleton generator, computes a straight skeleton for the input polygon, reusable. 
+	/// A straight skeleton generator, computes a straight skeleton for the input polygon, reusable.
 	/// The generation algorithm is loosely based on the work of Tom Kelly
 	/// (2014) "Unwritten procedural modeling with the straight skeleton"
 	/// http://www.twak.co.uk/2014/02/unwritten-procedural-modeling-with.html
 	/// </summary>
-	public class StraightSkeletonGenerator
+	internal class StraightSkeletonGenerator
 	{
 		private readonly List<Plan> activePlans = new List<Plan>();
 		private readonly List<Plan> newPlans = new List<Plan>();

--- a/MREGodotRuntimeLib/ProceduralToolkit/Godot/GodotExtensions.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Godot/GodotExtensions.cs
@@ -3,7 +3,7 @@ using Godot;
 
 namespace Godot
 {
-    public static class GodotExtensions
+    internal static class GodotExtensions
     {
         /// <summary>
         /// Returns the signed angle to the given vector, in radians.

--- a/MREGodotRuntimeLib/ProceduralToolkit/Godot/Ray.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Godot/Ray.cs
@@ -2,7 +2,7 @@
 namespace Godot
 {
     //Dummy class
-    public class Ray
+    internal class Ray
     {
         public Vector3 origin;
 		public Vector3 direction;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Godot/Ray2D.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Godot/Ray2D.cs
@@ -2,7 +2,7 @@
 namespace Godot
 {
     //Dummy class
-    public class Ray2D
+    internal class Ray2D
     {
         public Vector2 origin;
 		public Vector2 direction;

--- a/MREGodotRuntimeLib/ProceduralToolkit/Godot/Vector2i.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/Godot/Vector2i.cs
@@ -15,7 +15,7 @@ namespace Godot
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
-    public struct Vector2i : IEquatable<Vector2i>
+    internal struct Vector2i : IEquatable<Vector2i>
     {
         /// <summary>
         /// Enumerated index values for the axes.

--- a/MREGodotRuntimeLib/ProceduralToolkit/MeshDraft.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/MeshDraft.cs
@@ -8,7 +8,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// Helper class for procedural mesh generation
 	/// </summary>
 	[Serializable]
-	public partial class MeshDraft
+	internal partial class MeshDraft
 	{
 		public string name = "";
 		public List<Vector3> vertices = new List<Vector3>();

--- a/MREGodotRuntimeLib/ProceduralToolkit/MeshDraftPrimitives.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/MeshDraftPrimitives.cs
@@ -8,7 +8,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Helper class for procedural mesh generation
 	/// </summary>
-	public partial class MeshDraft
+	internal partial class MeshDraft
 	{
 		#region Platonic solids
 

--- a/MREGodotRuntimeLib/ProceduralToolkit/PTUtils.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/PTUtils.cs
@@ -7,7 +7,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Various useful methods and constants
 	/// </summary>
-	public static class PTUtils
+	internal static class PTUtils
 	{
 		/// <summary>
 		/// Lowercase letters from a to z

--- a/MREGodotRuntimeLib/ProceduralToolkit/VectorE.cs
+++ b/MREGodotRuntimeLib/ProceduralToolkit/VectorE.cs
@@ -6,7 +6,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 	/// <summary>
 	/// Vector extensions
 	/// </summary>
-	public static class VectorE
+	internal static class VectorE
 	{
 		#region Vector2
 
@@ -89,7 +89,7 @@ namespace MixedRealityExtension.ProceduralToolkit
 		/// <param name="to">The angle extends round to this vector</param>
 		public static float SignedAngle(Vector2 from, Vector2 to)
 		{
-			
+
 			return Mathf.Rad2Deg(Mathf.Atan2(PerpDot(to, from), to.Dot(from)));
 		}
 


### PR DESCRIPTION
The classes in Proceduraltoolkit are used internally to create meshes
for Actor.
There are no public APIs that use them, and they don't need to be public.