### PR TITLE
lib: fix AttachmentComponent free issue.

### DIFF
--- a/MREGodotRuntimeLib/Core/Actor.cs
+++ b/MREGodotRuntimeLib/Core/Actor.cs
@@ -819,9 +819,9 @@ namespace MixedRealityExtension.Core
 						var attachmentComponent = attachPoint.AddNode(new MREAttachmentComponent());
 						attachmentComponent.Actor = this;
 						attachmentComponent.UserId = Attachment.UserId;
-
 						attachmentComponent.Transform = this.Transform;
 						hostAppUser.BeforeAvatarDestroyed += UserInfo_BeforeAvatarDestroyed;
+						Connect("tree_exited", this, nameof(ActorTreeExited), new Godot.Collections.Array() { attachmentComponent });
 						return true;
 					}
 				}
@@ -833,6 +833,12 @@ namespace MixedRealityExtension.Core
 
 			return false;
 		}
+
+		private void ActorTreeExited(Spatial attachmentComponent)
+		{
+			attachmentComponent.QueueFree();
+		}
+
 		private void UserInfo_BeforeAvatarDestroyed()
 		{
 			// Remember the original local transform.


### PR DESCRIPTION
`AttachmentComponent`'s parent is 'attach point' that is not children of actor.
Which means `AttachmentComponent` is not deleted event if the actor is deleted.
This patch deletes it with `tree_exited` signal of actor.