### PR TITLE
runtime: remove unnecessary type check

### DIFF
--- a/MREGodotRuntime/Scripts/Tools/TargetTool.cs
+++ b/MREGodotRuntime/Scripts/Tools/TargetTool.cs
@@ -226,15 +226,12 @@ namespace Assets.Scripts.Tools
 
 				for (var node = (Spatial)RayIntersectionResult["collider"]; node != null; node = node.GetParent() as Spatial)
 				{
-					if (node is MixedRealityExtension.Core.Actor a)
+					var hitPointNormal = (Vector3)RayIntersectionResult["normal"];
+					inputSource.HitPoint = (Vector3)hitPoint;
+					inputSource.HitPointNormal = hitPointNormal;
+					if (node.GetChild<TargetBehavior>() != null)
 					{
-						var hitPointNormal = (Vector3)RayIntersectionResult["normal"];
-						inputSource.HitPoint = (Vector3)hitPoint;
-						inputSource.HitPointNormal = hitPointNormal;
-						if (node.GetChild<TargetBehavior>() != null)
-						{
-							return a;
-						}
+						return node;
 					}
 				}
 


### PR DESCRIPTION
If a node that `TargetBehavior` as a child, it's an Actor, so there is no need
to check it's an Actor type.