### PR TITLE
lib: duplicate resources in prefab creation

### DIFF
--- a/MREGodotRuntimeLib/Assets/AssetLoader.cs
+++ b/MREGodotRuntimeLib/Assets/AssetLoader.cs
@@ -128,12 +128,29 @@ namespace MixedRealityExtension.Assets
 					|| go.GetType() == typeof(Skeleton)
 					|| go.GetType() == typeof(BoneAttachment))
 				{
+					DuplicateResources(go);
+
 					var newActor = Actor.Instantiate((Spatial)go);
 					actorList.Add(newActor);
 				}
 			});
 
 			return actorList;
+		}
+
+		private void DuplicateResources(Godot.Object o)
+		{
+			foreach (Godot.Collections.Dictionary p in o.GetPropertyList())
+			{
+				var propertyName = (string)p["name"];
+				if (o.Get(propertyName) is Resource resource)
+				{
+					var newResource = resource.Duplicate();
+					o.Set(propertyName, newResource);
+
+					DuplicateResources(newResource);
+				}
+			}
 		}
 
 		[CommandHandler(typeof(LoadAssets))]


### PR DESCRIPTION
It seems that `Node.Duplicate` isn't duplicate its reosurces.
If you have multiple actors with same prefab's id and you change an actor's
resouce, the other actor's resource will also change.
This is not the expected behavior.
To fix this issue, it duplicates resources of nodes at prefab creation time.