### PR TITLE
lib: rewrite GodotWebRequest

### DIFF
--- a/MREGodotRuntimeLib/Util/Godot/GodotWebRequest.cs
+++ b/MREGodotRuntimeLib/Util/Godot/GodotWebRequest.cs
@@ -1,121 +1,104 @@
 using System;
 using System.IO;
-using System.Collections.Generic;
-using Godot;
+using System.Net;
+using System.Net.Http;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MixedRealityExtension.Util.GodotHelper
 {
-    internal class GodotWebRequest : SceneTree
-    {
-        Uri uri;
-        Error err;
-        HTTPClient.Method method;
+	// This class is from https://github.com/KhronosGroup/UnityGLTF.
+	internal class GodotWebRequest : IDisposable
+	{
+		private readonly HttpClient httpClient = new HttpClient();
+		private readonly Uri baseAddress;
 
-        private static Dictionary<string, HTTPClient> clientCache = new Dictionary<string, HTTPClient>();
+		public event Action<HttpRequestMessage> BeforeRequestCallback;
 
-        private List<string> headers = new List<string>();
-        private Godot.Collections.Dictionary responseHeadersDictionary;
-        private long responseCode;
-        public GodotWebRequest(Uri uri, HTTPClient.Method method = HTTPClient.Method.Get)
-        {
-            this.uri = uri;
-            this.method = method;
-        }
+		/// <summary>
+		/// The HTTP response of the last call to LoadStream
+		/// </summary>
+		public HttpResponseMessage LastResponse { get; private set; }
 
-        public void SetRequestHeader(string name, string value)
-        {
-            headers.Add($"{name}: {value}");
-        }
+		public GodotWebRequest(string rootUri)
+		{
+			ServicePointManager.ServerCertificateValidationCallback = ValidateServerCertificate;
+			string path = System.IO.Path.GetFileName(rootUri);
+			string host = rootUri.Substring(0, rootUri.Length - path.Length);
+			baseAddress = new Uri(host);
+		}
 
-        public long GetResponseCode()
-        {
-            return responseCode;
-        }
+		public async Task<MemoryStream> LoadStreamAsync(string gltfFilePath)
+		{
+			if (gltfFilePath == null)
+			{
+				throw new ArgumentNullException(nameof(gltfFilePath));
+			}
 
-        public string GetResponseHeader(string key)
-        {
-            return responseHeadersDictionary[key] as string;
-        }
+			if (LastResponse != null)
+			{
+				LastResponse.Dispose();
+				LastResponse = null;
+			}
 
-        public async Task<MemoryStream> LoadStreamAsync()
-        {
-            if (!clientCache.TryGetValue(uri.Host, out HTTPClient client))
-            {
-                client = new HTTPClient();
-                clientCache[uri.Host] = client;
-            }
-            err = client.ConnectToHost(uri.Host, uri.Port);
-            if (err != Error.Ok)
-            {
-                GD.PrintErr($"Failed to connect to host: {uri}. Error: {err}.");
-                return null;
-            }
+			try
+			{
 
-            while (client.GetStatus() == HTTPClient.Status.Connecting || client.GetStatus() == HTTPClient.Status.Resolving)
-            {
-                client.Poll();
-                OS.DelayMsec(10);
-            }
-            if (client.GetStatus() != HTTPClient.Status.Connected)
-            {
-                GD.PrintErr($"Failed to connect to host: {uri}. Error: {err}.");
-                return null;
-            }
+				var tokenSource = new CancellationTokenSource(30000);
+				var message = new HttpRequestMessage(HttpMethod.Get, new Uri(baseAddress, gltfFilePath));
+				BeforeRequestCallback?.Invoke(message);
+				LastResponse = await httpClient.SendAsync(message, tokenSource.Token);
+			}
+			catch (TaskCanceledException)
+			{
+				throw new HttpRequestException("Connection timeout");
+			}
 
-            err = client.Request(method, uri.PathAndQuery, headers.ToArray());
-            if (err != Error.Ok)
-            {
-                GD.PrintErr($"Failed to sends a request to the connected host: {uri}. Error: {err}.");
-                return null;
-            }
+			LastResponse.EnsureSuccessStatusCode();
 
-            while (client.GetStatus() == HTTPClient.Status.Requesting)
-            {
-                client.Poll();
-                if (OS.HasFeature("web"))
-                {
-                    // Synchronous HTTP requests are not supported on the web,
-                    // so wait for the next main loop iteration.
-                    await ToSignal(Engine.GetMainLoop(), "idle_frame");
-                }
-                else
-                {
-                    OS.DelayMsec(10);
-                }
-            }
-            if (client.GetStatus() != HTTPClient.Status.Body && client.GetStatus() != HTTPClient.Status.Connected)
-            {
-                GD.PrintErr($"Failed to sends a request to the connected host: {uri}. Error: {err}.");
-                return null;
-            }
+			// HACK: Download the whole file before returning the stream
+			// Ideally the parsers would wait for data to be available, but they don't.
+			var result = new MemoryStream((int?)LastResponse.Content.Headers.ContentLength ?? 5000);
+			await LastResponse.Content.CopyToAsync(result);
+			return result;
+		}
 
-            MemoryStream stream = null;
-            if (client.HasResponse())
-            {
-                stream = new MemoryStream();
+		// enables HTTPS support
+		// https://answers.unity.com/questions/50013/httpwebrequestgetrequeststream-https-certificate-e.html
+		private static bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors errors)
+		{
+			bool isOk = true;
+			// If there are errors in the certificate chain, look at each error to determine the cause.
+			if (errors != SslPolicyErrors.None)
+			{
+				for (int i = 0; i<chain.ChainStatus.Length; i++)
+				{
+					if (chain.ChainStatus[i].Status != X509ChainStatusFlags.RevocationStatusUnknown)
+					{
+						chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
+						chain.ChainPolicy.RevocationMode = X509RevocationMode.Online;
+						chain.ChainPolicy.UrlRetrievalTimeout = new TimeSpan(0, 1, 0);
+						chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
+						bool chainIsValid = chain.Build((X509Certificate2)certificate);
+						if (!chainIsValid)
+						{
+							isOk = false;
+						}
+					}
+				}
+			}
 
-                while (client.GetStatus() == HTTPClient.Status.Body)
-                {
-                    client.Poll();
-                    byte[] chunk = client.ReadResponseBodyChunk();
-                    if (chunk.Length == 0)
-                    {
-                        OS.DelayMsec(10);
-                    }
-                    else
-                    {
-                        stream.Write(chunk, 0, chunk.Length);
-                    }
-                }
-                stream.Position = 0;
-            }
+			return isOk;
+		}
 
-            responseCode = client.GetResponseCode();
-            responseHeadersDictionary = client.GetResponseHeadersAsDictionary();
-            client.Close();
-
-            return stream;
-        }
-    }
+		public void Dispose()
+		{
+			if (LastResponse != null)
+			{
+				LastResponse.Dispose();
+			}
+		}
+	}
 }


### PR DESCRIPTION
Godot's HTTP API doesn't seem to work well in an asynchronous environment.
This replaces GodotWebRequest's implementation with UnityGLTF's one.