### PR TITLE
Download server's manifest after confirming server connection

### DIFF
--- a/MREGodotRuntimeLib/API/MREApi.cs
+++ b/MREGodotRuntimeLib/API/MREApi.cs
@@ -168,7 +168,16 @@ namespace MixedRealityExtension.API
 			{
 				if (typeof(MREPlugin).IsAssignableFrom(type))
 				{
-					var MREPlugin = (MREPlugin)Activator.CreateInstance(type, new object[] { app });
+					MREPlugin MREPlugin;
+					try
+					{
+						MREPlugin = (MREPlugin)Activator.CreateInstance(type, new object[] { app });
+					}
+					catch (Exception e)
+					{
+						GD.PushError(e.ToString());
+						continue;
+					}
 					app.RegisterCommandHandlers(new Dictionary<Type, ICommandHandlerContext>()
 					{
 						{ type, MREPlugin },

--- a/MREGodotRuntimeLib/Messaging/Commands/CommandManager.cs
+++ b/MREGodotRuntimeLib/Messaging/Commands/CommandManager.cs
@@ -137,13 +137,13 @@ namespace MixedRealityExtension.Messaging.Commands
 			foreach (var commandHandlerPair in commandHandlers)
 			{
 				// Build table of handler to method info.
-				_methodHandlersByContextType.Add(commandHandlerPair.Key,
+				_methodHandlersByContextType[commandHandlerPair.Key] =
 					new Type[] { commandHandlerPair.Key }
 						.SelectMany(t => t.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance))
 						.Where(m => m.GetCustomAttributes().OfType<CommandHandler>().Any())
-						.ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType));
+						.ToDictionary(m => m.GetCustomAttributes().OfType<CommandHandler>().First().CommandType);
 
-				_invocationTargets.Add(commandHandlerPair.Key, commandHandlerPair.Value);
+				_invocationTargets[commandHandlerPair.Key] = commandHandlerPair.Value;
 			}
 		}
 


### PR DESCRIPTION
- The patch also changes the way to store a plugin's type and instance in the dictionary.
- It allows clients to connect a server even when the server is found while clients running.
- It allows clients to re-connect a server after having a disconnection issue.

Co-authored-by: id213sin <id213sin@gmail.com>